### PR TITLE
Add regression models and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # Progetto Simulazione CALPHAD
+
+Questa repository contiene semplici strumenti per il calcolo di alcune proprietà dei materiali.
+
+## Moduli principali
+
+- **models.py** implementa modelli di regressione per modulo elastico e durezza,
+  il calcolo del parametro di Larson–Miller per la rottura a creep e una legge
+  parabolica semplificata per la crescita di ossidi.
+- **cli.py** offre una semplice interfaccia a riga di comando per utilizzare i
+  modelli.
+- **gui.py** mette a disposizione una piccola interfaccia grafica basata su
+  Tkinter.
+- **export.py** permette di esportare i risultati in formato CSV o JSON.
+
+## Utilizzo da riga di comando
+
+Esempio di fit del modulo elastico:
+
+```bash
+python cli.py fit-modulus --temperatures 300 400 500 --values 200 180 160 --out coeffs.json
+```
+
+Calcolo del parametro di Larson–Miller:
+
+```bash
+python cli.py creep-rupture --temperature 1000 --time 1000
+```
+
+## Avvio della GUI
+
+```bash
+python gui.py
+```

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,99 @@
+import argparse
+import numpy as np
+from models import (
+    PolynomialModel,
+    fit_elastic_modulus,
+    fit_hardness,
+    larson_miller_parameter,
+    oxide_thickness,
+)
+from export import export_csv, export_json
+
+
+def parse_array(values: list[str]) -> np.ndarray:
+    return np.array([float(v) for v in values])
+
+
+def cmd_fit_modulus(args: argparse.Namespace) -> None:
+    model = fit_elastic_modulus(parse_array(args.temperatures), parse_array(args.values), args.degree)
+    coeffs = model.coeffs.tolist()
+    print("coefficients:", coeffs)
+    if args.out:
+        export_json(args.out, {"coefficients": coeffs})
+
+
+def cmd_fit_hardness(args: argparse.Namespace) -> None:
+    model = fit_hardness(parse_array(args.temperatures), parse_array(args.values), args.degree)
+    coeffs = model.coeffs.tolist()
+    print("coefficients:", coeffs)
+    if args.out:
+        export_json(args.out, {"coefficients": coeffs})
+
+
+def cmd_predict(args: argparse.Namespace) -> None:
+    model = PolynomialModel(np.array(args.coeffs, dtype=float))
+    value = model.predict(args.temperature)
+    print(args.property, value)
+
+
+def cmd_creep(args: argparse.Namespace) -> None:
+    lmp = larson_miller_parameter(args.temperature, args.time, args.C)
+    print("Larson-Miller parameter:", lmp)
+    if args.out:
+        export_csv(args.out, {"LMP": lmp})
+
+
+def cmd_oxide(args: argparse.Namespace) -> None:
+    thickness = oxide_thickness(args.kp, args.time, args.initial)
+    print("Oxide thickness:", thickness)
+    if args.out:
+        export_csv(args.out, {"thickness": thickness})
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="CALPHAD simulation tools")
+    sub = parser.add_subparsers(dest="command")
+
+    fm = sub.add_parser("fit-modulus")
+    fm.add_argument("--temperatures", nargs="+", required=True)
+    fm.add_argument("--values", nargs="+", required=True)
+    fm.add_argument("--degree", type=int, default=1)
+    fm.add_argument("--out", help="export results to JSON")
+    fm.set_defaults(func=cmd_fit_modulus)
+
+    fh = sub.add_parser("fit-hardness")
+    fh.add_argument("--temperatures", nargs="+", required=True)
+    fh.add_argument("--values", nargs="+", required=True)
+    fh.add_argument("--degree", type=int, default=1)
+    fh.add_argument("--out", help="export results to JSON")
+    fh.set_defaults(func=cmd_fit_hardness)
+
+    pred = sub.add_parser("predict")
+    pred.add_argument("property", choices=["modulus", "hardness"])
+    pred.add_argument("--coeffs", nargs="+", type=float, required=True)
+    pred.add_argument("--temperature", type=float, required=True)
+    pred.set_defaults(func=cmd_predict)
+
+    creep = sub.add_parser("creep-rupture")
+    creep.add_argument("--temperature", type=float, required=True)
+    creep.add_argument("--time", type=float, required=True, help="hours")
+    creep.add_argument("--C", type=float, default=20.0)
+    creep.add_argument("--out", help="export CSV")
+    creep.set_defaults(func=cmd_creep)
+
+    oxide = sub.add_parser("oxide-growth")
+    oxide.add_argument("--kp", type=float, required=True)
+    oxide.add_argument("--time", type=float, required=True)
+    oxide.add_argument("--initial", type=float, default=0.0)
+    oxide.add_argument("--out", help="export CSV")
+    oxide.set_defaults(func=cmd_oxide)
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/export.py
+++ b/export.py
@@ -1,0 +1,19 @@
+"""Utility functions to export calculated results."""
+import csv
+import json
+from typing import Mapping, Any
+
+
+def export_csv(filename: str, data: Mapping[str, Any]) -> None:
+    """Write dictionary data to a CSV file."""
+    with open(filename, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["property", "value"])
+        for key, value in data.items():
+            writer.writerow([key, value])
+
+
+def export_json(filename: str, data: Mapping[str, Any]) -> None:
+    """Write dictionary data to a JSON file."""
+    with open(filename, "w") as f:
+        json.dump(data, f, indent=2)

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,127 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+import numpy as np
+from models import (
+    fit_elastic_modulus,
+    fit_hardness,
+    larson_miller_parameter,
+    oxide_thickness,
+)
+
+class App(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("CALPHAD Tools")
+        self.geometry("300x300")
+        self.create_widgets()
+
+    def create_widgets(self):
+        notebook = ttk.Notebook(self)
+        notebook.pack(fill="both", expand=True)
+
+        self.mod_frame = ttk.Frame(notebook)
+        self.hard_frame = ttk.Frame(notebook)
+        self.creep_frame = ttk.Frame(notebook)
+        self.oxide_frame = ttk.Frame(notebook)
+
+        notebook.add(self.mod_frame, text="Modulus")
+        notebook.add(self.hard_frame, text="Hardness")
+        notebook.add(self.creep_frame, text="Creep")
+        notebook.add(self.oxide_frame, text="Oxide")
+
+        self.build_modulus()
+        self.build_hardness()
+        self.build_creep()
+        self.build_oxide()
+
+    def build_modulus(self):
+        ttk.Label(self.mod_frame, text="Temperatures (comma)").pack()
+        self.mod_temp = tk.Entry(self.mod_frame)
+        self.mod_temp.pack()
+        ttk.Label(self.mod_frame, text="Values (comma)").pack()
+        self.mod_val = tk.Entry(self.mod_frame)
+        self.mod_val.pack()
+        ttk.Button(self.mod_frame, text="Fit", command=self.on_fit_modulus).pack()
+        self.mod_result = ttk.Label(self.mod_frame, text="")
+        self.mod_result.pack()
+
+    def build_hardness(self):
+        ttk.Label(self.hard_frame, text="Temperatures (comma)").pack()
+        self.hard_temp = tk.Entry(self.hard_frame)
+        self.hard_temp.pack()
+        ttk.Label(self.hard_frame, text="Values (comma)").pack()
+        self.hard_val = tk.Entry(self.hard_frame)
+        self.hard_val.pack()
+        ttk.Button(self.hard_frame, text="Fit", command=self.on_fit_hardness).pack()
+        self.hard_result = ttk.Label(self.hard_frame, text="")
+        self.hard_result.pack()
+
+    def build_creep(self):
+        ttk.Label(self.creep_frame, text="Temperature (K)").pack()
+        self.creep_temp = tk.Entry(self.creep_frame)
+        self.creep_temp.pack()
+        ttk.Label(self.creep_frame, text="Time (h)").pack()
+        self.creep_time = tk.Entry(self.creep_frame)
+        self.creep_time.pack()
+        ttk.Button(self.creep_frame, text="Compute LMP", command=self.on_creep).pack()
+        self.creep_result = ttk.Label(self.creep_frame, text="")
+        self.creep_result.pack()
+
+    def build_oxide(self):
+        ttk.Label(self.oxide_frame, text="k_p").pack()
+        self.oxide_kp = tk.Entry(self.oxide_frame)
+        self.oxide_kp.pack()
+        ttk.Label(self.oxide_frame, text="Time (s)").pack()
+        self.oxide_time = tk.Entry(self.oxide_frame)
+        self.oxide_time.pack()
+        ttk.Button(self.oxide_frame, text="Thickness", command=self.on_oxide).pack()
+        self.oxide_result = ttk.Label(self.oxide_frame, text="")
+        self.oxide_result.pack()
+
+    def parse_list(self, entry: tk.Entry):
+        return np.array([float(v) for v in entry.get().split(',') if v])
+
+    def on_fit_modulus(self):
+        try:
+            temps = self.parse_list(self.mod_temp)
+            vals = self.parse_list(self.mod_val)
+            model = fit_elastic_modulus(temps, vals)
+            self.mod_result.config(text=f"Coeffs: {model.coeffs}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+    def on_fit_hardness(self):
+        try:
+            temps = self.parse_list(self.hard_temp)
+            vals = self.parse_list(self.hard_val)
+            model = fit_hardness(temps, vals)
+            self.hard_result.config(text=f"Coeffs: {model.coeffs}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+    def on_creep(self):
+        try:
+            T = float(self.creep_temp.get())
+            t = float(self.creep_time.get())
+            lmp = larson_miller_parameter(T, t)
+            self.creep_result.config(text=f"LMP: {lmp:.2f}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+    def on_oxide(self):
+        try:
+            kp = float(self.oxide_kp.get())
+            t = float(self.oxide_time.get())
+            th = oxide_thickness(kp, t)
+            self.oxide_result.config(text=f"Thickness: {th:.3g}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+
+def main():
+    app = App()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,41 @@
+import numpy as np
+from dataclasses import dataclass
+
+@dataclass
+class PolynomialModel:
+    """Simple polynomial regression model."""
+    coeffs: np.ndarray
+
+    def predict(self, x: float | np.ndarray) -> np.ndarray:
+        return np.polyval(self.coeffs, x)
+
+
+def fit_polynomial(x: np.ndarray, y: np.ndarray, degree: int) -> PolynomialModel:
+    """Fit a polynomial of given degree to the data."""
+    coeffs = np.polyfit(x, y, degree)
+    return PolynomialModel(coeffs)
+
+
+def fit_elastic_modulus(temperatures: np.ndarray, values: np.ndarray, degree: int = 1) -> PolynomialModel:
+    """Return a model predicting elastic modulus as a function of temperature."""
+    return fit_polynomial(np.asarray(temperatures), np.asarray(values), degree)
+
+
+def fit_hardness(temperatures: np.ndarray, values: np.ndarray, degree: int = 1) -> PolynomialModel:
+    """Return a model predicting hardness as a function of temperature."""
+    return fit_polynomial(np.asarray(temperatures), np.asarray(values), degree)
+
+
+def larson_miller_parameter(temperature: float, time_hours: float, C: float = 20.0) -> float:
+    """Compute the Larson–Miller parameter (LMP). Temperature in Kelvin."""
+    return temperature * (C + np.log10(time_hours))
+
+
+def time_from_lmp(LMP: float, temperature: float, C: float = 20.0) -> float:
+    """Return creep rupture time in hours from LMP and temperature."""
+    return 10 ** (LMP / temperature - C)
+
+
+def oxide_thickness(kp: float, time_seconds: float, initial: float = 0.0) -> float:
+    """Simple parabolic oxide growth law x^2 = x0^2 + k_p * t."""
+    return np.sqrt(initial ** 2 + kp * time_seconds)


### PR DESCRIPTION
## Summary
- implement polynomial models for elastic modulus and hardness
- add Larson-Miller creep rupture and oxide growth in `models.py`
- provide CLI for fitting and predicting properties as well as creep/oxide tools
- create a simple Tkinter GUI
- add export helpers and update README with usage examples

## Testing
- `python3 -m py_compile models.py cli.py gui.py export.py`
- `python3 - <<'PY'
from models import fit_elastic_modulus, larson_miller_parameter, oxide_thickness
import numpy as np
model = fit_elastic_modulus(np.array([300,400,500]), np.array([200,180,160]))
print('coeffs', model.coeffs)
print('predict 450', model.predict(450))
print('lmp', larson_miller_parameter(1000, 1000))
print('oxide', oxide_thickness(1e-6, 3600))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6855ced00b988327af71018484a10f0a